### PR TITLE
kafka mirror link updated

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 kafka_download_timeout_seconds: 600
 kafka_install_parent_dir: /usr/local
 
-kafka_mirror: https://downloads.apache.org/kafka
+kafka_mirror: https://archive.apache.org/dist/kafka
 kafka_scala_ver: '2.13'
 kafka_ver: 3.4.0
 


### PR DESCRIPTION
The current mirror link has only 3.4.0 and 3.5.1
https://downloads.apache.org/kafka/ 

This updated archive link has all version of kafka https://archive.apache.org/dist/kafka/